### PR TITLE
Move mobile menu state into component, restore metadata

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,39 +1,36 @@
-"use client";
-
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
-import { useState } from "react";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export default function RootLayout({ children }) {
-  const [isOpen, setIsOpen] = useState(false);
+export const metadata = {
+  title: "SF Hacks 2025",
+  description: "Bigger, Better, with more Air Fryers",
+  icons: [{ rel: "icon", url: "/favicon.ico" }],
+};
 
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
+export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <head>
-        {/* Should Replace this with a metadata object in the future */}
-        <title>SF Hacks</title>
-      </head>
-			<body className={`${inter.className}`} style={{backgroundColor: "#16133d"}}>
-				<Navbar isOpen={isOpen} handleToggle={handleToggle} />
-				<main
-					className="pt-24 pb-24 bg-webdev-temp"
-					style={{
-						minHeight: "100vh",
-						height: "max-content",
+      <body
+        className={`${inter.className}`}
+        style={{ backgroundColor: "#16133d" }}
+      >
+        <Navbar />
+        <main
+          className="pt-24 pb-24 bg-webdev-temp"
+          style={{
+            minHeight: "100vh",
+            height: "max-content",
             backgroundSize: "auto 100vh",
             backgroundPosition: "top",
-            backgroundRepeat: "no-repeat"
-					}}
-				>
-					{children}
-				</main>
-			</body>
+            backgroundRepeat: "no-repeat",
+          }}
+        >
+          {children}
+        </main>
+      </body>
     </html>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Menu, X } from "lucide-react";
+import { useState } from "react";
 
 // Set menu links here
 const NAV_LINKS = [
@@ -129,7 +130,13 @@ const MobileMenu = ({ isOpen, handleToggle }) => {
   );
 };
 
-export default function Navbar({ isOpen, handleToggle }) {
+export default function Navbar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-40 flex items-center justify-center p-4">
       <div className="hidden md:block">


### PR DESCRIPTION
I saw the comment @ChilRx left about metadata in the layout file. I had unintentionally removed it when I was fixing the mobile hamburger menu in order to use hooks in the root layout. This should re-add the meta data while moving the state management into the nav bar component.